### PR TITLE
Add Kubernetes manifests for Minikube deployment

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,47 @@
+# Kubernetes deployment
+
+Este diretório contém os manifestos Kubernetes necessários para executar o projeto `system-education` em um cluster local (por exemplo, usando o Minikube).
+
+## Recursos
+
+- `configmap.yaml`: define as variáveis de ambiente da aplicação e da conexão com o banco de dados.
+- `secret.yaml`: armazena a senha do banco de dados.
+- `deployment.yaml`: cria o deployment que executa o container com a aplicação na porta 8080.
+- `service.yaml`: expõe a aplicação internamente no cluster na porta 8080.
+
+## Executando com Minikube
+
+1. Inicie o Minikube e configure seu shell para utilizar o Docker interno do cluster:
+
+   ```bash
+   minikube start
+   eval "$(minikube -p minikube docker-env)"
+   ```
+
+2. Faça o build da imagem da aplicação utilizando o Docker do Minikube (o Dockerfile expõe a porta 8080):
+
+   ```bash
+   docker build -t system-education:latest .
+   ```
+
+3. Aplique os manifestos Kubernetes:
+
+   ```bash
+   kubectl apply -f k8s/
+   ```
+
+4. Verifique se os pods estão prontos:
+
+   ```bash
+   kubectl get pods
+   ```
+
+5. Para acessar a aplicação fora do cluster, exponha o serviço via `port-forward` ou crie um `NodePort`. Exemplo com `port-forward`:
+
+   ```bash
+   kubectl port-forward service/system-education 8080:8080
+   ```
+
+   Depois disso, a aplicação estará acessível em `http://localhost:8080`.
+
+> **Observação:** os manifestos assumem um banco de dados PostgreSQL acessível a partir do cluster com as credenciais definidas no `ConfigMap` e `Secret`. Ajuste os valores conforme o ambiente desejado.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: system-education-config
+  labels:
+    app: system-education
+data:
+  APP_NAME: "system-education"
+  APP_ENV: "production"
+  APP_PORT: "8080"
+  DB_HOST: "system-education-db"
+  DB_PORT: "5432"
+  DB_USERNAME: "postgres"
+  DB_DATABASE: "system_education"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-education
+  labels:
+    app: system-education
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: system-education
+  template:
+    metadata:
+      labels:
+        app: system-education
+    spec:
+      containers:
+        - name: system-education
+          image: system-education:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: system-education-config
+            - secretRef:
+                name: system-education-secret
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: system-education-secret
+  labels:
+    app: system-education
+type: Opaque
+stringData:
+  DB_PASSWORD: "postgres"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: system-education
+  labels:
+    app: system-education
+spec:
+  selector:
+    app: system-education
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for deploying the application with environment variables on port 8080
- document Minikube workflow for building the image and applying the manifests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908f2279350832b89b3446dd3b5698a