### PR TITLE
Add workflow to auto-create PRs after Go CI success

### DIFF
--- a/.github/workflows/create-pr-after-go-ci-success.yml
+++ b/.github/workflows/create-pr-after-go-ci-success.yml
@@ -1,0 +1,71 @@
+name: Create PR After Go CI Success
+
+on:
+  workflow_run:
+    workflows: ['Go CI & Codecov']
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ensure_pull_request:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure PR exists for successful workflow run
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          script: |
+            const runId = context.payload.workflow_run.id;
+            const { owner, repo } = context.repo;
+
+            const { data: run } = await github.rest.actions.getWorkflowRun({
+              owner,
+              repo,
+              run_id: runId,
+            });
+
+            const headBranch = run.head_branch;
+
+            if (!headBranch) {
+              core.notice('Nenhum branch associado ao workflow. Nada a fazer.');
+              return;
+            }
+
+            if (headBranch === 'main') {
+              core.notice("Pulando criação de PR para o branch 'main'.");
+              return;
+            }
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${headBranch}`,
+            });
+
+            if (existing.length > 0) {
+              core.notice(`PR #${existing[0].number} já existe para o branch ${headBranch}.`);
+              return;
+            }
+
+            const title = `Automated PR from ${headBranch}`;
+            const body = 'Esta PR foi criada automaticamente após o sucesso dos testes no workflow **Go CI & Codecov**.';
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner,
+              repo,
+              head: headBranch,
+              base: 'main',
+              title,
+              body,
+              draft: false,
+            });
+
+            core.notice(`PR #${pr.number} criada automaticamente para o branch ${headBranch}.`);
+


### PR DESCRIPTION
## Summary
- add a workflow_run-triggered automation that creates a pull request when Go CI & Codecov passes
- skip PR creation for the main branch and when a PR already exists

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_69092b41c140832bbd75d7103bd416bb