### PR TITLE
Add Helm chart for system-education deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 [![codecov](https://codecov.io/github/williamkoller/payment-system/graph/badge.svg?token=NXB84FNDRR)](https://codecov.io/github/williamkoller/payment-system)
 # Payment Education
 
+## Deploy com Helm
+
+Um chart Helm está disponível em `helm/system-education` para automatizar o deploy do projeto em um cluster Kubernetes. Consulte o arquivo [`helm/README.md`](helm/README.md) para obter instruções detalhadas de instalação e atualização das imagens da aplicação.

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,54 @@
+# system-education Helm chart
+
+Este diretório contém um chart Helm para automatizar o deploy dos recursos Kubernetes utilizados pelo projeto `system-education`.
+
+## Pré-requisitos
+
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- Um cluster Kubernetes com acesso a um registry que contenha a imagem da aplicação `system-education`
+- Opcional: `kubectl` configurado no contexto do cluster para validações manuais
+
+## Estrutura do chart
+
+- `Chart.yaml`: metadados do chart
+- `values.yaml`: valores padrão utilizados pelos templates. Aqui você pode definir o repositório, tag e política de pull da imagem da aplicação, além de configurações do banco de dados PostgreSQL
+- Diretório `templates/`: contém todos os manifests renderizados pelo Helm. Os arquivos criam ConfigMap, Secret, Deployment e Service da aplicação, além de (opcionalmente) os recursos para executar uma instância do PostgreSQL dentro do cluster
+
+## Instalação
+
+1. Atualize o `values.yaml` ou utilize parâmetros `--set` para configurar o deploy. Por exemplo, para apontar para uma imagem publicada no registry `ghcr.io/<sua-org>/system-education` com a tag `1.0.0`:
+
+   ```bash
+   helm upgrade --install system-education helm/system-education \
+     --namespace system-education --create-namespace \
+     --set image.repository=ghcr.io/<sua-org>/system-education \
+     --set image.tag=1.0.0
+   ```
+
+   > **Dica:** defina `image.pullPolicy=Always` (valor padrão) para garantir que o cluster sempre busque a última versão disponibilizada com a tag informada.
+
+2. Para atualizar a aplicação após publicar uma nova imagem, execute novamente o comando `helm upgrade` informando a nova tag (por exemplo, `--set image.tag=1.1.0`). O Helm irá atualizar o Deployment e forçar o Kubernetes a recriar os pods com a nova imagem.
+
+3. Caso utilize o PostgreSQL embarcado, os dados serão armazenados em um `PersistentVolumeClaim`. Para desabilitar a criação desse banco, utilize `--set postgresql.enabled=false` e ajuste as variáveis de ambiente conforme o seu banco externo.
+
+## Como verificar o deploy
+
+- Listar os pods:
+
+  ```bash
+  kubectl get pods -n system-education
+  ```
+
+- Fazer port-forward para acessar a aplicação localmente:
+
+  ```bash
+  kubectl port-forward svc/system-education 8080:8080 -n system-education
+  ```
+
+- Visualizar os valores atualmente aplicados pelo Helm:
+
+  ```bash
+  helm get values system-education -n system-education
+  ```
+
+Com isso, o deploy do Kubernetes passa a ser gerenciado pelo Helm, simplificando atualizações de versão da imagem e manutenção dos manifestos.

--- a/helm/system-education/Chart.yaml
+++ b/helm/system-education/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: system-education
+version: 0.1.0
+appVersion: "0.1.0"
+description: Helm chart for deploying the system-education application and its PostgreSQL dependency.
+type: application

--- a/helm/system-education/templates/NOTES.txt
+++ b/helm/system-education/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Thank you for deploying system-education with Helm!
+
+1. Verify the status of the release:
+   kubectl get pods -n {{ .Release.Namespace }}
+
+2. Forward the service port locally if running on a private cluster:
+   kubectl port-forward svc/{{ include "system-education.fullname" . }} 8080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+The application will be available on http://localhost:8080

--- a/helm/system-education/templates/_helpers.tpl
+++ b/helm/system-education/templates/_helpers.tpl
@@ -1,0 +1,34 @@
+{{- define "system-education.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "system-education.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "system-education.chart" -}}
+{{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}
+
+{{- define "system-education.labels" -}}
+helm.sh/chart: {{ include "system-education.chart" . }}
+{{ include "system-education.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "system-education.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "system-education.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/system-education/templates/configmap.yaml
+++ b/helm/system-education/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "system-education.fullname" . }}
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+data:
+  APP_NAME: {{ .Values.config.appName | quote }}
+  APP_PORT: {{ .Values.config.appPort | quote }}
+  DB_HOST: {{ .Values.config.database.host | quote }}
+  DB_PORT: {{ .Values.config.database.port | quote }}
+  DB_USERNAME: {{ .Values.config.database.username | quote }}
+  DB_DATABASE: {{ .Values.config.database.name | quote }}
+  DB_SSLMODE: {{ .Values.config.database.sslmode | quote }}
+  DB_TIMEZONE: {{ .Values.config.database.timezone | quote }}
+  DB_LOG: {{ .Values.config.database.log | quote }}
+  DB_MAX_IDLE_CONNS: {{ .Values.config.database.maxIdleConns | quote }}
+  DB_MAX_OPEN_CONNS: {{ .Values.config.database.maxOpenConns | quote }}
+  DB_CONN_MAX_LIFETIME_MIN: {{ .Values.config.database.connMaxLifetimeMin | quote }}
+  {{- range $key, $value := .Values.env.extra }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/helm/system-education/templates/deployment.yaml
+++ b/helm/system-education/templates/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "system-education.fullname" . }}
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "system-education.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "system-education.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: {{ include "system-education.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+              name: http
+          envFrom:
+            - configMapRef:
+                name: {{ include "system-education.fullname" . }}
+            - secretRef:
+                name: {{ include "system-education.fullname" . }}-secret
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/system-education/templates/postgres.yaml
+++ b/helm/system-education/templates/postgres.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.postgresql.enabled }}
+{{- if .Values.postgresql.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "system-education.fullname" . }}-db-pvc
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size }}
+  {{- with .Values.postgresql.persistence.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "system-education.fullname" . }}-db
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database
+      {{- include "system-education.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: database
+        {{- include "system-education.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "system-education.fullname" . }}
+                  key: DB_DATABASE
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "system-education.fullname" . }}
+                  key: DB_USERNAME
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "system-education.fullname" . }}-secret
+                  key: DB_PASSWORD
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgres-data
+      volumes:
+        - name: postgres-data
+          {{- if .Values.postgresql.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "system-education.fullname" . }}-db-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "system-education.fullname" . }}-db
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/component: database
+    {{- include "system-education.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: 5432
+      targetPort: postgres
+      name: postgres
+{{- end }}

--- a/helm/system-education/templates/secret.yaml
+++ b/helm/system-education/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "system-education.fullname" . }}-secret
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DB_PASSWORD: {{ .Values.secrets.dbPassword | quote }}

--- a/helm/system-education/templates/service.yaml
+++ b/helm/system-education/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "system-education.fullname" . }}
+  labels:
+    {{- include "system-education.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "system-education.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/helm/system-education/values.yaml
+++ b/helm/system-education/values.yaml
@@ -1,0 +1,56 @@
+image:
+  repository: system-education
+  tag: latest
+  pullPolicy: Always
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 8080
+
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: 14.2-alpine
+    pullPolicy: IfNotPresent
+  persistence:
+    enabled: true
+    storageClassName: ""
+    size: 1Gi
+
+config:
+  appName: system-education
+  appPort: "8080"
+  database:
+    host: system-education-db
+    port: "5432"
+    username: admin
+    name: db-system-education
+    sslmode: disable
+    timezone: America/Sao_Paulo
+    log: "true"
+    maxIdleConns: "10"
+    maxOpenConns: "100"
+    connMaxLifetimeMin: "30"
+
+secrets:
+  dbPassword: Q1w2e3r4t5y6u7i8o9p0[-]=
+
+env:
+  extra: {}
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,4 +1,6 @@
-# Kubernetes deployment
+# Kubernetes deployment (legado)
+
+> **Observação:** Recomendamos utilizar o chart Helm disponível em [`../helm/system-education`](../helm/system-education) para fazer o deploy automatizado do projeto. Os manifestos neste diretório são mantidos apenas como referência histórica.
 
 Este diretório contém os manifestos Kubernetes necessários para executar o projeto `system-education` em um cluster local (por exemplo, usando o Minikube).
 
@@ -9,7 +11,6 @@ Este diretório contém os manifestos Kubernetes necessários para executar o pr
 - `deployment.yaml`: cria o deployment que executa o container com a aplicação na porta 8080.
 - `service.yaml`: expõe a aplicação internamente no cluster na porta 8080.
 - `postgres-deployment.yaml`: provisiona um banco PostgreSQL com `PersistentVolumeClaim` e serviço interno.
-
 
 ## Executando com Minikube
 
@@ -41,7 +42,6 @@ Este diretório contém os manifestos Kubernetes necessários para executar o pr
    ```
 
 6. Para acessar a aplicação fora do cluster, exponha o serviço via `port-forward` ou crie um `NodePort`. Exemplo com `port-forward`:
-
 
    ```bash
    kubectl port-forward service/system-education 8080:8080


### PR DESCRIPTION
## Summary
- add a Helm chart that templates the application, configuration, and PostgreSQL resources for Kubernetes
- document how to install and upgrade the release using Helm and point existing docs to the new workflow

## Testing
- not run (helm CLI not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_690b68251c84832b97b17164ba6808f5